### PR TITLE
chore(ci): fail PRs that introduce vulnerable dependencies

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,14 @@
+# Renovate reports vulnerabilities already on main; this one blocks a PR that
+# is about to add a new dependency with a known advisory. It only looks at what
+# the PR adds, so it stays quiet about pre-existing findings.
+
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  dependency-review:
+    uses: EduIDE/.github/.github/workflows/dependency-review.yml@v1


### PR DESCRIPTION
## What and why

Renovate already tells us about vulnerable dependencies sitting on `main`. Nothing stopped a PR from *adding* a new one.

This wires up the shared reusable workflow `EduIDE/.github/.github/workflows/dependency-review.yml@v1`. It runs `actions/dependency-review-action` over the PR diff and fails the check when the PR introduces a dependency with a known advisory at **high** severity or above (the reusable workflow's default). It only looks at what the PR adds, so pre-existing findings do not block anyone.

There is no general-purpose CI workflow here - `build.yml` and `package.yml` are each single-purpose - so this lands as its own `.github/workflows/dependency-review.yml`, triggered on PRs to `main` to match them.

## How it was verified

- `actionlint` 1.7.6 run over this repo's workflows. The file changed here is clean. Pre-existing findings in workflows this PR does not touch were left alone.
- This PR is itself the first run of the check - see the `dependency-review` entry in the checks list. It adds no dependencies, so it is expected to pass.
- The underlying API needs the repo to be public (or GitHub Advanced Security on a private repo). This repo is public.

## Deployment impact

- [ ] Requires a config or secret change
- [ ] Requires a migration
- [ ] Changes a published artifact or image
- [x] CI-only change, no runtime impact

## Risk and rollback

Low. The change adds a read-only PR check and touches nothing that ships. The one way it can bite: a PR that legitimately needs a dependency carrying a high-severity advisory gets blocked until the dependency is upgraded or swapped.

Rollback: revert this commit. To soften it instead, pass a higher `fail-on-severity` to the reusable workflow.
